### PR TITLE
Bump adoption of UCO to 1.2.0

### DIFF
--- a/ontology/master/ae.ttl
+++ b/ontology/master/ae.ttl
@@ -1,6 +1,6 @@
 # imports: https://ontology.adversaryengagement.org/ae/engagement/0.0.1
 # imports: https://ontology.adversaryengagement.org/ae/vocabulary/0.0.1
-# imports: https://ontology.unifiedcyberontology.org/uco/uco/1.0.0
+# imports: https://ontology.unifiedcyberontology.org/uco/uco/1.2.0
 
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -23,7 +23,7 @@
 		<https://ontology.adversaryengagement.org/ae/objective/0.0.1> ,
 		<https://ontology.adversaryengagement.org/ae/role/0.0.1> ,
 		<https://ontology.adversaryengagement.org/ae/vocabulary/0.0.1> ,
-		<https://ontology.unifiedcyberontology.org/uco/uco/1.0.0>
+		<https://ontology.unifiedcyberontology.org/uco/uco/1.2.0>
 		;
 	owl:versionIRI <https://ontology.adversaryengagement.org/ae/ae/0.0.1> ;
 	owl:versionInfo "0.0.1" ;


### PR DESCRIPTION
UCO follows semantic versioning, so releases since 1.0.0 and prior to 2.0.0 should be backwards-compatible with the version currently OWL-imported by the Adversary Engagement Ontology.

1.2.0 is the current UCO release.

References:
* https://unifiedcyberontology.org/releases/1.2.0/